### PR TITLE
chore: grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      gomod-all:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-all:
+        patterns: ["*"]


### PR DESCRIPTION
Add grouped Dependabot config (Console Labs consolidation hardening , dependency-alert remediation).

Dependabot alerts + automated security updates are now enabled on this repo; this `.github/dependabot.yml` GROUPS the bumps (one PR per ecosystem instead of dozens) and keeps deps current weekly. Ecosystems detected from the repo's manifests (gomod / npm / github-actions).

Security-fix PRs will flow automatically from Dependabot; merge them after CI. No source change here, just the config.
