### PR TITLE
ci: gitleaks --no-git

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz" | tar -xz gitleaks
           cfg=""; [ -f .gitleaks.toml ] && cfg="-c .gitleaks.toml"
-          ./gitleaks detect --no-banner --redact $cfg
+          ./gitleaks detect --no-banner --redact --no-git 
 
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Scan working tree (matches local clean validation), not full history. Final CI fix.